### PR TITLE
Add best-practice template

### DIFF
--- a/best-practice/document.adoc
+++ b/best-practice/document.adoc
@@ -1,0 +1,82 @@
+= Calendar operator practices -- Guidelines to protect against calendar abuse
+:comment: ### Best Practice Template
+:comment: ### Title of the document
+:title: Calendar operator practices -- Guidelines to protect against calendar abuse
+:comment: ### Numeric component of the document identifier
+:docnumber: 333
+:comment: ### Document status. See comment 1.
+:status: final-draft
+:comment: ### Document type. See comment 2.
+:doctype: best-practice
+:comment: ### Document edition
+:edition: 1
+:comment: ### Document version
+:version: 1.0
+:comment: ### Year of copyright
+:copyright-year: 2018
+:comment: ### Last update date
+:revdate: 2018-10-31
+:comment: ### Date on which the standard was published (distributed by the publisher).
+:published-date: 2018-10-31
+:comment: ### Full name of a person who is contributor to the document.
+:fullname: Thomas Schäfer
+:comment: ### Organization that the contributor is affiliated with.
+:affiliation: 1&1 Mail&Media Development and Technology GmbH
+:fullname_2: Jesse Thompson
+:affiliation_2: University of Wisconsin-Madison
+:comment: ### Document language.
+:language: en
+:comment: ### Name of the relevant technical committee
+:technical-committee: CalConnect TC CALSPAM
+:comment: ### Draft status, enables display of reviewer notes; remove if final document
+:draft:
+:comment: ### Name of this AsciiDoc file
+:docfile: document.adoc
+:comment: ### Metanorma flavour: applies to all ISO documents
+:mn-document-class: m3aawg
+:comment: ### Desired output formats. Metanorma-ISO supports the following output extension values: xml (MN XML), html (ISO-style HTML), html_alt (pretty HTML), doc (Word .doc)
+:mn-output-extensions: xml,html,doc,rxl
+:local-cache-only:
+:data-uri-image:
+
+
+////
+Comment 1: Status
+
+Permitted values are:
+- proposal
+- working-draft
+- committee-draft
+- draft-standard
+- final-draft
+- published
+- withdrawn
+
+
+Comment 2: doctype
+
+Permitted values are:
+- policy
+- best-practices
+- supporting-document
+- report
+////
+
+
+include::sections/00-foreword.adoc[]
+
+include::sections/00-introduction.adoc[]
+
+include::sections/01-scope.adoc[]
+
+include::sections/02-normref.adoc[]
+
+include::sections/03-termdef.adoc[]
+
+include::sections/04-content.adoc[]
+
+include::sections/a1-annex.adoc[]
+
+include::sections/a2-annex.adoc[]
+
+include::sections/zz-bibliography.adoc[]

--- a/best-practice/document.adoc
+++ b/best-practice/document.adoc
@@ -10,8 +10,6 @@
 :doctype: best-practice
 :comment: ### Document edition
 :edition: 1
-:comment: ### Document version
-:version: 1.0
 :comment: ### Year of copyright
 :copyright-year: 2018
 :comment: ### Last update date

--- a/best-practice/sections/00-foreword.adoc
+++ b/best-practice/sections/00-foreword.adoc
@@ -1,0 +1,34 @@
+
+.Foreword
+The Calendaring and Scheduling Consortium ("`CalConnect`") is global non-profit
+organization with the aim of facilitating interoperability of technologies across
+user-centric systems and applications.
+
+CalConnect works closely with liaison partners including international
+organizations such as ISO, OASIS and M3AAWG.
+
+The procedures used to develop this document and those intended for its further
+maintenance are described in the CalConnect Directives, and in this case, also aligned
+with the procedures used at M3AAWG.
+
+In particular the different approval criteria needed for the different types of
+CalConnect documents should be noted. This document was drafted in accordance with the
+editorial rules of the CalConnect Directives.
+
+Attention is drawn to the possibility that some of the elements of this
+document may be the subject of patent rights. CalConnect shall not be held responsible
+for identifying any or all such patent rights. Details of any patent rights
+identified during the development of the document will be in the Introduction
+and/or on the CalConnect list of patent declarations received (see
+www.calconnect.com/patents).
+
+Any trade name used in this document is information given for the convenience
+of users and does not constitute an endorsement.
+
+This document was prepared by Technical Committee _{technical-committee}_.
+
+Authors:
+
+Thomas Schäfer, 1&1 Mail&Media Development and Technology GmbH
+
+Jesse Thompson, University of Wisconsin-Madison

--- a/best-practice/sections/00-introduction.adoc
+++ b/best-practice/sections/00-introduction.adoc
@@ -1,5 +1,5 @@
 
-:sectnums!:
+[.preface]
 == Introduction
 
 // Insert introduction here.

--- a/best-practice/sections/00-introduction.adoc
+++ b/best-practice/sections/00-introduction.adoc
@@ -1,0 +1,24 @@
+
+:sectnums!:
+== Introduction
+
+// Insert introduction here.
+
+=== Rise of calendar spam
+
+"`Calendar spam`" -- unsolicited, or otherwise unwanted, calendar events and meeting
+invitations -- is a recently exploited channel for abuse aimed at users of
+calendaring & scheduling systems.
+
+It is a new form of application-specific spam which takes advantage of the application
+layer across multiple technologies that spans scheduling, calendaring and messaging
+systems.
+
+As is the case with email spam, calendar spam is not only used to deliver unwanted
+information, but can also be used for malicious purposes such as phishing attempts
+and delivering dangerous payloads.
+
+Because calendar events and meeting invitations are often (but not exclusively)
+transported and delivered via email, combatting calendar spam requires awareness,
+intervention and integration with email systems and services.
+

--- a/best-practice/sections/01-scope.adoc
+++ b/best-practice/sections/01-scope.adoc
@@ -1,5 +1,5 @@
 
-:sectnums:
+
 == Scope
 
 // Insert scope here.

--- a/best-practice/sections/01-scope.adoc
+++ b/best-practice/sections/01-scope.adoc
@@ -1,0 +1,13 @@
+
+:sectnums:
+== Scope
+
+// Insert scope here.
+
+This document specifies guidelines for calendar and mail system operators to:
+
+* detect the occurrence of calendar abuse;
+
+* consider processes and procedures to mitigate calendar abuse; and
+
+* suggest acceptable (non-abusive) practices with calendar usage.

--- a/best-practice/sections/02-normref.adoc
+++ b/best-practice/sections/02-normref.adoc
@@ -1,0 +1,10 @@
+
+
+[bibliography]
+== Normative references
+
+// Insert references here.
+
+* [[[iMIP,IETF RFC 6047]]], _iCalendar Message-Based Interoperability Protocol (iMIP)_
+
+* [[[iTIP,IETF RFC 5546]]], _iCalendar Transport-Independent Interoperability Protocol (iTIP)_

--- a/best-practice/sections/03-termdef.adoc
+++ b/best-practice/sections/03-termdef.adoc
@@ -1,0 +1,71 @@
+
+[[terms]]
+== Terms, definitions and abbreviations
+
+=== Terms and definitions
+
+[[calendar-spam]]
+==== calendar spam
+
+calendar events and meeting invitations containing _spam_ (<<term-spam>>) delivered
+through _calendar systems_ (<<term-calendar-system>>)
+
+
+[[term-calendar-abuse]]
+==== calendar abuse
+
+malicious usage of a _calendar system_ (<<term-calendar-system>>),
+possibly leading to an _attack_ (<<ISO27000,clause 3.2>>)
+on the receiving user
+
+
+[[term-spam]]
+==== spam
+
+unsolicited or unwanted information
+
+
+[[attack]]
+==== attack
+
+attempt to destroy, expose, alter, disable, steal or gain unauthorized
+access to or make unauthorized use of an asset
+
+[.source]
+<<ISO27000>>
+
+
+[[term-calendar-system]]
+==== calendar system
+
+information system that provides calendar and scheduling functionality for user
+accounts
+
+
+[[mail-system]]
+==== mail system
+
+information system that provides electronic mail functionality
+
+
+[[user-system]]
+==== user system
+
+information system that provides authentication and authorization functionality
+
+
+
+[[abbrev]]
+=== Abbreviations
+
+iMIP:: iCalendar Message-Based Interoperability Protocol (see <<iMIP>>)
+
+iTIP:: iCalendar Transport-Independent Interoperability Protocol (see <<iTIP>>)
+
+SMTP:: Simple Mail Transfer Protocol (see <<SMTP>>)
+
+DNSBL:: Domain Name System-based Blackhole List
+
+URIBL:: Realtime URI Blacklist
+
+ARF:: Abuse Reporting Format

--- a/best-practice/sections/03-termdef.adoc
+++ b/best-practice/sections/03-termdef.adoc
@@ -7,15 +7,15 @@
 [[calendar-spam]]
 ==== calendar spam
 
-calendar events and meeting invitations containing _spam_ (<<term-spam>>) delivered
-through _calendar systems_ (<<term-calendar-system>>)
+calendar events and meeting invitations containing term:[spam] delivered
+through term:[calendar systems,calendar system]
 
 
 [[term-calendar-abuse]]
 ==== calendar abuse
 
-malicious usage of a _calendar system_ (<<term-calendar-system>>),
-possibly leading to an _attack_ (<<ISO27000,clause 3.2>>)
+malicious usage of a term:[calendar system]
+possibly leading to an term:[attack]
 on the receiving user
 
 

--- a/best-practice/sections/04-content.adoc
+++ b/best-practice/sections/04-content.adoc
@@ -1,0 +1,8 @@
+
+[[content]]
+== Main content
+
+// Here's where you place your main content.
+Main content.
+
+

--- a/best-practice/sections/a1-annex.adoc
+++ b/best-practice/sections/a1-annex.adoc
@@ -1,0 +1,7 @@
+
+// If no obligation value is set, the annex is presumed to be normative
+[[annex-1]]
+[appendix]
+== Annex One
+
+This is a normative annex.

--- a/best-practice/sections/a2-annex.adoc
+++ b/best-practice/sections/a2-annex.adoc
@@ -1,0 +1,7 @@
+
+// If no obligation value is set, the annex is presumed to be normative
+[[annex-2]]
+[appendix,obligation="informative"]
+== Annex Two
+
+This is an informative annex.

--- a/best-practice/sections/zz-bibliography.adoc
+++ b/best-practice/sections/zz-bibliography.adoc
@@ -1,0 +1,7 @@
+
+[bibliography]
+== Bibliography
+
+* [[[ISO27000,ISO/IEC 27000:2018]]], _Information technology -- Security techniques -- Information security management systems -- Overview and vocabulary_
+
+* [[[SMTP,IETF RFC 2821]]], _Simple Mail Transfer Protocol (SMTP)_ https://www.ietf.org/rfc/rfc2821.txt


### PR DESCRIPTION
*As requested in https://github.com/metanorma/metanorma/issues/53*

I took the unique sample located in [mn-samples-m3aawg](https://github.com/metanorma/mn-samples-m3aawg) as a base to create this template.

Comments/questions:
* In the preamble of the document, there are `:edition: 1` and `:version: 1.0`. However, [documentation](https://www.metanorma.com/author/m3aawg/authoring/) states that `:edition:` is used to capture document version. Does that mean that we should discard `:version:` attribute?
* The `term:[]` attribute seems not to be working in this flavor. So, old-fashioned markup is used for the term cross-references. I have opened a ticket about it in https://github.com/metanorma/metanorma-m3aawg/issues/67.
* Do we have samples for these types: `policy`, `supporting-document`, `report`?